### PR TITLE
Do the things

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,11 +10,13 @@
 
 import React from 'react';
 import {SafeAreaView, StatusBar, useColorScheme, View} from 'react-native';
-
+import { PersistGate } from 'redux-persist/integration/react';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 import PhotoCaptureView from './src/ui/PhotoCaptureView';
 import {Provider} from 'react-redux';
 import {store} from './src/store';
+import { persistStore } from 'redux-persist';
+
 import {NativeRouter, Route, Routes} from 'react-router-native';
 import PhotoListView from './src/ui/PhotoListView';
 
@@ -23,23 +25,27 @@ const backgroundStyle = {
   flex: 1,
 };
 
+let persistor = persistStore(store);
+
 const App = () => {
   return (
     <NativeRouter>
       <Provider store={store}>
-        <SafeAreaView style={backgroundStyle}>
-          <StatusBar barStyle={'light-content'} />
-          <View
-            style={{
-              backgroundColor: Colors.white,
-              flex: 1,
-            }}>
-            <Routes>
-              <Route path="/" element={<PhotoListView />} />
-              <Route path="/capture" element={<PhotoCaptureView />} />
-            </Routes>
-          </View>
-        </SafeAreaView>
+        <PersistGate loading={null} persistor={persistor}>
+          <SafeAreaView style={backgroundStyle}>
+            <StatusBar barStyle={'light-content'} />
+            <View
+              style={{
+                backgroundColor: Colors.white,
+                flex: 1,
+              }}>
+              <Routes>
+                <Route path="/" element={<PhotoListView />} />
+                <Route path="/capture" element={<PhotoCaptureView />} />
+              </Routes>
+            </View>
+          </SafeAreaView>
+        </PersistGate>
       </Provider>
     </NativeRouter>
   );

--- a/README.txt
+++ b/README.txt
@@ -11,17 +11,17 @@ yarn run android
 
 
 Work through as many of these goals as you can:
-- Fix lint warnings and lint errors in MultiPhotoCapture.tsx
-- Find out why the app fails when scanning errorCode.png, and fix the problem.
-- Fix the warning showing up when rendering the list of products.
+- [x] Fix lint warnings and lint errors in MultiPhotoCapture.tsx
+- [x] Find out why the app fails when scanning errorCode.png, and fix the problem.
+- [x] Fix the warning showing up when rendering the list of products.
 - Add "tap to focus" when tapping on the camera view:
   - a circle 64px in diameter should appear for 2 seconds at the tap location.
   - the camera should focus on the related area. See documentation here: 
     https://react-native-camera.github.io/react-native-camera/docs/rncamera#autofocuspointofinterest
 - Make the redux store persistent (right now it's only in memory, so it's cleared on restart).
 - Make the list of photo + lot numbers on the home page prettier:
-  - add sensible margin vertically and horizontally between each rows.
-  - make each item in a row, with lot number on the left, and photo on the right.
-  - Add a delete icon to each row, clicking on it should remove the item and associated files.
+  - [x] add sensible margin vertically and horizontally between each rows.
+  - [x] make each item in a row, with lot number on the left, and photo on the right.
+  - [x] Add a delete icon to each row, clicking on it should remove the item and associated files.
 
 

--- a/README.txt
+++ b/README.txt
@@ -18,7 +18,7 @@ Work through as many of these goals as you can:
   - a circle 64px in diameter should appear for 2 seconds at the tap location.
   - the camera should focus on the related area. See documentation here: 
     https://react-native-camera.github.io/react-native-camera/docs/rncamera#autofocuspointofinterest
-- Make the redux store persistent (right now it's only in memory, so it's cleared on restart).
+- [x] Make the redux store persistent (right now it's only in memory, so it's cleared on restart).
 - Make the list of photo + lot numbers on the home page prettier:
   - [x] add sensible margin vertically and horizontally between each rows.
   - [x] make each item in a row, with lot number on the left, and photo on the right.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.16.1",
     "@reduxjs/toolkit": "^1.7.2",
     "js-sha256": "^0.9.0",
     "react": "17.0.2",
@@ -20,7 +21,8 @@
     "react-native-paper": "^4.11.2",
     "react-native-vector-icons": "^9.1.0",
     "react-redux": "^7.2.6",
-    "react-router-native": "^6.2.1"
+    "react-router-native": "^6.2.1",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,22 @@
 import {configureStore} from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import photosReducer from './photos';
+import { persistReducer } from 'redux-persist';
+
+const persistConfig = {
+  key: 'root',
+  storage: AsyncStorage,
+};
+
+const persistedReducer = persistReducer(persistConfig, photosReducer);
 
 export const store = configureStore({
   reducer: {
-    photos: photosReducer,
+    photos: persistedReducer,
   },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware({
+    serializableCheck: false,
+  })
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/photos.ts
+++ b/src/store/photos.ts
@@ -20,10 +20,15 @@ export const photoSlice = createSlice({
       // immutable state based off those changes
       state.value.push(action.payload);
     },
+    deletePhoto: (state: PhotosState, action: PayloadAction<PhotoItem>) => {
+      state.value = state.value.filter(e => {
+        return e.photoFilePath !==  action.payload.photoFilePath
+      });
+    }
   },
 });
 
 // Action creators are generated for each case reducer function
-export const {addPhoto} = photoSlice.actions;
+export const {addPhoto, deletePhoto} = photoSlice.actions;
 
 export default photoSlice.reducer;

--- a/src/ui/FocusCircle.tsx
+++ b/src/ui/FocusCircle.tsx
@@ -21,7 +21,7 @@ interface State {
 
 class FocusCircle extends React.Component<Props, State> {
     state: State = {
-        timer: 3,
+        timer: 2,
         intervalId: setInterval(() => {}),
         animation : new Animated.Value(0),
 };

--- a/src/ui/FocusCircle.tsx
+++ b/src/ui/FocusCircle.tsx
@@ -24,67 +24,67 @@ class FocusCircle extends React.Component<Props, State> {
         timer: 2,
         intervalId: setInterval(() => {}),
         animation : new Animated.Value(0),
-};
+    };
 
-constructor(props: Props) {
-    super(props);
-    this._timer = this._timer.bind(this);
-    this._fadeIn = this._fadeIn.bind(this);
-    this._fadeOut = this._fadeOut.bind(this);
-};
+    constructor(props: Props) {
+        super(props);
+        this._timer = this._timer.bind(this);
+        this._fadeIn = this._fadeIn.bind(this);
+        this._fadeOut = this._fadeOut.bind(this);
+    };
 
-componentDidMount() {
-    let intervalId = setInterval(this._timer, 2000);
-    this.setState({intervalId: intervalId});
-    requestAnimationFrame(this._fadeIn);
-};
+    componentDidMount() {
+        let intervalId = setInterval(this._timer, 2000);
+        this.setState({intervalId: intervalId});
+        requestAnimationFrame(this._fadeIn);
+    };
 
-componentWillUnmount() {
-    clearInterval(this.state.intervalId);
-};
-
-_timer() {
-    this.setState({ timer: this.state.timer - 1 });
-
-    if (this.state.timer === 1) { 
-        requestAnimationFrame(this._fadeOut);
-    }
-
-    if (this.state.timer < 1) {
-        this.props.onAnimationEnd(this.props.id);
+    componentWillUnmount() {
         clearInterval(this.state.intervalId);
+    };
+
+    _timer() {
+        this.setState({ timer: this.state.timer - 1 });
+
+        if (this.state.timer === 1) { 
+            requestAnimationFrame(this._fadeOut);
+        }
+
+        if (this.state.timer < 1) {
+            this.props.onAnimationEnd(this.props.id);
+            clearInterval(this.state.intervalId);
+        }
+    };
+
+    _fadeIn = () => {
+        Animated.timing(this.state.animation, {
+            toValue: 1,
+            duration: 300,
+            useNativeDriver: true,
+        } as any).start();
+    };
+
+    _fadeOut = () => {
+        Animated.timing(this.state.animation, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+        } as any).start();
+    };
+
+    render() {
+        return (
+            <Animated.View 
+                key={this.props.id}
+                style={[styles.focusCircle, 
+                    {
+                        left: this.props.left, 
+                        top: this.props.top,
+                        opacity: this.state.animation,
+                    }]} 
+            />
+        )
     }
-};
-
-_fadeIn = () => {
-    Animated.timing(this.state.animation, {
-        toValue: 1,
-        duration: 300,
-        useNativeDriver: true,
-    } as any).start();
-};
-
-_fadeOut = () => {
-    Animated.timing(this.state.animation, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true,
-    } as any).start();
-};
-
-render() {
-    return (
-    <Animated.View 
-        key={this.props.id}
-        style={[styles.focusCircle, 
-            {
-                left: this.props.left, 
-                top: this.props.top,
-                opacity: this.state.animation,
-            }]} 
-    />
-    )
-}
 }
 
 export default FocusCircle;
@@ -102,5 +102,5 @@ const styles = StyleSheet.create({
         position: 'absolute', 
         marginLeft: FocusCircleHeight/2 * -1,
         marginTop: FocusCircleHeight/2 * -1,
-},
+    },
 });

--- a/src/ui/FocusCircle.tsx
+++ b/src/ui/FocusCircle.tsx
@@ -1,0 +1,106 @@
+import {
+    Animated,
+    Dimensions,
+    StyleSheet,
+} from 'react-native';
+
+import React from 'react';
+
+interface Props {
+    top: number,
+    left: number,
+    id: string,
+    onAnimationEnd: (id: string) => void,
+}
+
+interface State {
+    timer: number,
+    intervalId: NodeJS.Timer,
+    animation: Animated.Value,
+}
+
+class FocusCircle extends React.Component<Props, State> {
+    state: State = {
+        timer: 3,
+        intervalId: setInterval(() => {}),
+        animation : new Animated.Value(0),
+};
+
+constructor(props: Props) {
+    super(props);
+    this._timer = this._timer.bind(this);
+    this._fadeIn = this._fadeIn.bind(this);
+    this._fadeOut = this._fadeOut.bind(this);
+};
+
+componentDidMount() {
+    let intervalId = setInterval(this._timer, 2000);
+    this.setState({intervalId: intervalId});
+    requestAnimationFrame(this._fadeIn);
+};
+
+componentWillUnmount() {
+    clearInterval(this.state.intervalId);
+};
+
+_timer() {
+    this.setState({ timer: this.state.timer - 1 });
+
+    if (this.state.timer === 1) { 
+        requestAnimationFrame(this._fadeOut);
+    }
+
+    if (this.state.timer < 1) {
+        this.props.onAnimationEnd(this.props.id);
+        clearInterval(this.state.intervalId);
+    }
+};
+
+_fadeIn = () => {
+    Animated.timing(this.state.animation, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+    } as any).start();
+};
+
+_fadeOut = () => {
+    Animated.timing(this.state.animation, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+    } as any).start();
+};
+
+render() {
+    return (
+    <Animated.View 
+        key={this.props.id}
+        style={[styles.focusCircle, 
+            {
+                left: this.props.left, 
+                top: this.props.top,
+                opacity: this.state.animation,
+            }]} 
+    />
+    )
+}
+}
+
+export default FocusCircle;
+
+const FocusCircleHeight = 64;
+
+const styles = StyleSheet.create({
+    focusCircle: {
+        backgroundColor: 'transparent',
+        borderRadius: FocusCircleHeight/2,
+        borderWidth: 2,
+        borderColor: 'white',
+        height: FocusCircleHeight,
+        width: FocusCircleHeight,
+        position: 'absolute', 
+        marginLeft: FocusCircleHeight/2 * -1,
+        marginTop: FocusCircleHeight/2 * -1,
+},
+});

--- a/src/ui/MultiPhotoCapture.tsx
+++ b/src/ui/MultiPhotoCapture.tsx
@@ -52,11 +52,6 @@ export enum AnimState {
   ScanSuccess = 'ScanSuccess',
 }
 
-interface AutoFocusPoint {
-  x: number | null;
-  y: number | null;
-}
-
 interface State {
   cameraReady: boolean;
   capturing: boolean;
@@ -444,7 +439,7 @@ class MultiPhotoCapture extends React.Component<Props, State> {
     );
   };
 
-  _handleTap = ({x, y}: AutoFocusPoint) => {
+  _handleTap = ({x, y}: Point) => {
     if (x && y) {
       this.setState({autoFocusPoint: {x, y}});
     }

--- a/src/ui/MultiPhotoCapture.tsx
+++ b/src/ui/MultiPhotoCapture.tsx
@@ -453,21 +453,6 @@ class MultiPhotoCapture extends React.Component<Props, State> {
     );
   };
 
-  _handleTap = () => {
-    // don't know if this works
-    
-    // if (x && y) {
-
-    //   //this.setState({autoFocusPoint: {x, y}});
-    // }
-
-    // this.setState({autoFocusIndicatorVisible: true});
-
-    // setTimeout(() => this.setState({autoFocusIndicatorVisible: false}),
-    //   2000
-    // )
-  }
-
   _handlePress = (event: GestureResponderEvent) => {
     const { locationX: x, locationY: y} = event.nativeEvent;
 
@@ -501,7 +486,6 @@ class MultiPhotoCapture extends React.Component<Props, State> {
       <View style={styles.container}>
         <View style={styles.camera} onLayout={this._setCameraHeight}>
           <RNCamera
-            onTap={this._handleTap}
             autoFocusPointOfInterest={autoFocusPoint}
             androidCameraPermissionOptions={this._permissionVariables}
             captureAudio={false}

--- a/src/ui/PhotoCaptureView.tsx
+++ b/src/ui/PhotoCaptureView.tsx
@@ -21,7 +21,8 @@ const RDT_HEIGHT_PCT = 0.8;
 
 function pullLotNumberFromBarcode(barcodeData: string): string | undefined {
   const dataParts = (barcodeData || '').split(',');
-  const lotNumber = dataParts[1];
+  const lotNumber = dataParts[1] || '';
+
   if (lotNumber.length > 1) {
     return lotNumber;
   }

--- a/src/ui/PhotoListView.tsx
+++ b/src/ui/PhotoListView.tsx
@@ -1,15 +1,27 @@
 import React, {FC, ReactElement} from 'react';
-import {Image, ScrollView, StyleSheet, View} from 'react-native';
+import {Image, ScrollView, StyleSheet, View, TouchableOpacity} from 'react-native';
 import Text from './Text';
 import {Link} from 'react-router-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import {store} from '../store';
+import {RootState} from '../store';
 import {expandPath} from '../utils/filePath';
+import {PhotoItem} from '../types/types';
+import {useDispatch, useSelector} from 'react-redux';
+import {deletePhoto} from '../store/photos';
 
 const PhotoListView: FC = (): ReactElement => {
+  const dispatch = useDispatch();
+
+  const store = useSelector((state: RootState) => state);
+
   const content = [];
   for (let i = 0; i < 50; i++) {
     content.push(<Text content={'Welcome' + i} key={i} />);
+  }
+  function removeItem(photoItem: PhotoItem) {
+    dispatch(
+      deletePhoto(photoItem),
+    );
   }
   return (
     <ScrollView>
@@ -21,15 +33,25 @@ const PhotoListView: FC = (): ReactElement => {
           </View>
         </Link>
       </View>
-      <View>
-        {store.getState().photos.value.map(photoItem => {
+
+      <View style={styles.container}>
+        {store.photos.value.map((photoItem: PhotoItem)=> {
           return (
-            <View>
-              <Image
-                source={{uri: expandPath(photoItem.photoFilePath)}}
-                style={{width: 75, height: 100}}
-              />
-              <Text content={photoItem.lotNumber || 'No lot number'} />
+            <View key={photoItem.photoFilePath} style={[styles.photoItem, {
+              flexDirection: "row"
+            }]}>
+              <View style={{flex: 1, flexDirection: "column", justifyContent: "space-between"}}>
+                <Text style={styles.heading} content={photoItem.lotNumber || 'No lot number'} />
+                <TouchableOpacity onPress={() => removeItem(photoItem)}>
+                  <Icon name="trash-can-outline" style={styles.trashItemIcon} />
+                </TouchableOpacity>
+              </View>
+              <View style={{borderRadius: 8, overflow: 'hidden'}}>
+                <Image
+                  source={{uri: expandPath(photoItem.photoFilePath)}}
+                  style={{width: 75, height: 100}}
+                />
+              </View>
             </View>
           );
         })}
@@ -39,6 +61,11 @@ const PhotoListView: FC = (): ReactElement => {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    borderColor: 'lightgray',
+    borderBottomWidth: 2,
+    margin: 10,
+  },
   takePhotoButton: {
     alignItems: 'center',
     justifyContent: 'center',
@@ -49,6 +76,25 @@ const styles = StyleSheet.create({
     color: 'black',
     fontSize: 45,
   },
+  photoItem: {
+    backgroundColor: 'white',
+    justifyContent: 'space-between',
+    flex: 1,
+    paddingTop: 14,
+    paddingRight: 10,
+    paddingBottom: 14,
+    paddingLeft: 10,
+    borderColor: 'lightgray',
+    borderTopWidth: 2,
+  },
+  trashItemIcon: {
+    color: "red",
+    fontSize: 24,
+  },
+  heading: {
+    fontSize: 24, 
+    fontWeight: "600",
+  }
 });
 
 export default PhotoListView;


### PR DESCRIPTION
- [x] Fix lint warnings and lint errors in MultiPhotoCapture.tsx
- [x] Find out why the app fails when scanning errorCode.png, and fix the problem.
- [x] Fix the warning showing up when rendering the list of products.
- Add "tap to focus" when tapping on the camera view:
  - [x] a circle 64px in diameter should appear for 2 seconds at the tap location.
  - [x] the camera should focus on the related area. See documentation here: 
    https://react-native-camera.github.io/react-native-camera/docs/rncamera#autofocuspointofinterest
- [x] Make the redux store persistent (right now it's only in memory, so it's cleared on restart).
- Make the list of photo + lot numbers on the home page prettier:
  - [x] add sensible margin vertically and horizontally between each rows.
  - [x] make each item in a row, with lot number on the left, and photo on the right.
  - [x] Add a delete icon to each row, clicking on it should remove the item and associated files.


![Feb-28-2022 22-42-55](https://user-images.githubusercontent.com/260048/156118492-740b18ab-fc5f-4d3a-8626-ebd5a9ecd12c.gif)